### PR TITLE
Performance improvements for dynamics

### DIFF
--- a/cellpose/dynamics.py
+++ b/cellpose/dynamics.py
@@ -415,42 +415,48 @@ def labels_to_flows(labels, files=None, device=None, redo_flows=False, niter=Non
     return flows
 
 
-@njit([
-    "(int16[:,:,:], float32[:], float32[:], float32[:,:])",
-    "(float32[:,:,:], float32[:], float32[:], float32[:,:])"
-], cache=True)
+@njit(["(int16[:,:,:], float32[:], float32[:], float32[:,:])",
+       "(float32[:,:,:], float32[:], float32[:], float32[:,:])"],
+      parallel=True,
+      fastmath=True)
 def map_coordinates(I, yc, xc, Y):
     """
     Bilinear interpolation of image "I" in-place with y-coordinates yc and x-coordinates xc to Y.
-    
+
     Args:
         I (numpy.ndarray): Input image of shape (C, Ly, Lx).
         yc (numpy.ndarray): New y-coordinates.
         xc (numpy.ndarray): New x-coordinates.
         Y (numpy.ndarray): Output array of shape (C, ni).
-    
-    Returns:
-        None
     """
     C, Ly, Lx = I.shape
-    yc_floor = yc.astype(np.int32)
-    xc_floor = xc.astype(np.int32)
-    yc = yc - yc_floor
-    xc = xc - xc_floor
-    for i in range(yc_floor.shape[0]):
-        yf = min(Ly - 1, max(0, yc_floor[i]))
-        xf = min(Lx - 1, max(0, xc_floor[i]))
-        yf1 = min(Ly - 1, yf + 1)
-        xf1 = min(Lx - 1, xf + 1)
-        y = yc[i]
-        x = xc[i]
+    n_points = yc.shape[0]
+    for i in prange(n_points):
+        yf = int(yc[i])
+        xf = int(xc[i])
+
+        if yf < 0:
+            yf = 0
+        elif yf >= Ly:
+            yf = Ly - 1
+        if xf < 0:
+            xf = 0
+        elif xf >= Lx:
+            xf = Lx - 1
+
+        y_ratio = yc[i] - yf
+        x_ratio = xc[i] - xf
+        yf1 = yf + 1 if yf < Ly - 1 else yf
+        xf1 = xf + 1 if xf < Lx - 1 else xf
+
         for c in range(C):
-            Y[c, i] = (np.float32(I[c, yf, xf]) * (1 - y) * (1 - x) +
-                       np.float32(I[c, yf, xf1]) * (1 - y) * x +
-                       np.float32(I[c, yf1, xf]) * y * (1 - x) +
-                       np.float32(I[c, yf1, xf1]) * y * x)
+            Y[c, i] = (I[c, yf, xf] * (1 - y_ratio) * (1 - x_ratio) +
+                       I[c, yf, xf1] * (1 - y_ratio) * x_ratio +
+                       I[c, yf1, xf] * y_ratio * (1 - x_ratio) +
+                       I[c, yf1, xf1] * y_ratio * x_ratio)
 
 
+@njit(fastmath=True)
 def steps2D_interp(p, dP, niter, device=None):
     """ Run dynamics of pixels to recover masks in 2D, with interpolation between pixel values.
 
@@ -469,47 +475,21 @@ def steps2D_interp(p, dP, niter, device=None):
         None
 
     """
+    n_axes, n_points = p.shape
+    dPt = np.zeros_like(p)
 
-    shape = dP.shape[1:]
-    if device is not None and device.type == "cuda":
-        shape = np.array(shape)[[
-            1, 0
-        ]].astype("float") - 1  # Y and X dimensions (dP is 2.Ly.Lx), flipped X-1, Y-1
-        pt = torch.from_numpy(p[[1, 0]].T).float().to(device).unsqueeze(0).unsqueeze(
-            0)  # p is n_points by 2, so pt is [1 1 2 n_points]
-        im = torch.from_numpy(dP[[1, 0]]).float().to(device).unsqueeze(
-            0)  #covert flow numpy array to tensor on GPU, add dimension
-        # normalize pt between  0 and  1, normalize the flow
-        for k in range(2):
-            im[:, k, :, :] *= 2. / shape[k]
-            pt[:, :, :, k] /= shape[k]
-
-        # normalize to between -1 and 1
-        pt = pt * 2 - 1
-
-        #here is where the stepping happens
-        for t in range(niter):
-            # align_corners default is False, just added to suppress warning
-            dPt = torch.nn.functional.grid_sample(im, pt, align_corners=False)
-            for k in range(2):  #clamp the final pixel locations
-                pt[:, :, :, k] = torch.clamp(pt[:, :, :, k] + dPt[:, k, :, :], -1., 1.)
-
-        #undo the normalization from before, reverse order of operations
-        pt = (pt + 1) * 0.5
-        for k in range(2):
-            pt[:, :, :, k] *= shape[k]
-
-        p = pt[:, :, :, [1, 0]].cpu().numpy().squeeze().T
-        return p
-
-    else:
-        dPt = np.zeros(p.shape, np.float32)
-
-        for t in range(niter):
-            map_coordinates(dP.astype(np.float32), p[0], p[1], dPt)
-            for k in range(len(p)):
-                p[k] = np.minimum(shape[k] - 1, np.maximum(0, p[k] + dPt[k]))
-        return p
+    for t in range(niter):
+        map_coordinates(dP, p[0], p[1], dPt)
+        for i in range(n_axes):
+            max_val = dP.shape[i + 1] - 1
+            for j in range(n_points):
+                new_val = p[i, j] + dPt[i, j]
+                if new_val < 0.0:
+                    new_val = 0.0
+                elif new_val > max_val:
+                    new_val = max_val
+                p[i, j] = new_val
+    return p
 
 
 @njit("(float32[:,:,:,:],float32[:,:,:,:], int32[:,:], int32)", nogil=True)
@@ -588,11 +568,16 @@ def follow_flows(dP, mask=None, niter=200, interp=True, device=None):
             - inds (np.ndarray): Indices of pixels used for dynamics; [axis x Ly x Lx] or [axis x Lz x Ly x Lx].
     """
 
-    shape = np.array(dP.shape[1:]).astype(np.int32)
+    if dP.dtype != np.float32:
+        dP = dP.astype(np.float32)
+
+    shape = np.array(dP.shape[1:], dtype=np.int32)
     niter = np.uint32(niter)
 
     p = np.indices(shape, dtype=np.float32)  # bit faster than going through meshgrid, but mostly less memory-intensive
     inds = np.array(np.nonzero(np.abs(dP).max(axis=0) > 1e-3)).astype(np.int32).T
+    if inds.shape[0] == 0:
+        return p, inds
 
     if len(shape) > 2:
         # run dynamics on subset of pixels
@@ -605,14 +590,15 @@ def follow_flows(dP, mask=None, niter=200, interp=True, device=None):
         if not interp:
             p = steps2D(p, dP.astype(np.float32), inds, niter)
         else:
-            p_interp = steps2D_interp(p[:, inds[:, 0], inds[:, 1]], dP, niter, device=device)
-            for i in range(len(p)):  # somewhat faster than fancy indexing across the 0th axis
+            p_points = p[:, inds[:, 0], inds[:, 1]].copy()
+            p_interp = steps2D_interp(p_points, dP, np.int32(niter))
+            for i in range(p.shape[0]):
                 p[i, inds[:, 0], inds[:, 1]] = p_interp[i]
 
     return p, inds
 
 
-def remove_bad_flow_masks(masks, flows, threshold=0.4, device=None, logger=None):
+def remove_bad_flow_masks(masks, flows, threshold=0.4, device=None, multithread=True, logger=None):
     """Remove masks which have inconsistent flows.
 
     Uses metrics.flow_error to compute flows from predicted masks 

--- a/cellpose/dynamics.py
+++ b/cellpose/dynamics.py
@@ -318,7 +318,7 @@ def masks_to_flows_cpu(masks, device=None, niter=None):
     return mu, meds
 
 
-def masks_to_flows(masks, device=None, niter=None):
+def masks_to_flows(masks, device=None, niter=None, multithread=True):
     """Convert masks to flows using diffusion from center pixel.
 
     Center of masks where diffusion starts is defined to be the closest pixel to the mean of all pixels that is inside the mask.
@@ -326,6 +326,9 @@ def masks_to_flows(masks, device=None, niter=None):
 
     Args:
         masks (int, 2D or 3D array): Labelled masks 0=NO masks; 1,2,...=mask labels
+        device (torch.device, optional): Device to use for computation
+        niter (int, optional): Number of iterations for computing flows
+        multithread (bool, optional): Single-threaded vs. parallel computation with numba
 
     Returns:
         mu (float, 3D or 4D array): Flows in Y = mu[-2], flows in X = mu[-1].
@@ -335,13 +338,12 @@ def masks_to_flows(masks, device=None, niter=None):
         dynamics_logger.warning("empty masks!")
         return np.zeros((2, *masks.shape), "float32")
 
-    if device is not None:
-        if device.type == "cuda" or device.type == "mps":
-            masks_to_flows_device = masks_to_flows_gpu
-        else:
-            masks_to_flows_device = masks_to_flows_cpu_parallel
-    else:
+    if device is not None and (device.type == "cuda" or device.type == "mps"):
+        masks_to_flows_device = masks_to_flows_gpu
+    elif multithread:
         masks_to_flows_device = masks_to_flows_cpu_parallel
+    else:
+        masks_to_flows_device = masks_to_flows_cpu
 
     if masks.ndim == 3:
         Lz, Ly, Lx = masks.shape
@@ -642,7 +644,7 @@ def remove_bad_flow_masks(masks, flows, threshold=0.4, device=None, multithread=
 
     if logger is not None: logger.info(f'remove_bad_flow_masks: {device0=}')
     t1 = time.monotonic()
-    merrors, _ = metrics.flow_error(masks, flows, device0, logger=logger)
+    merrors, _ = metrics.flow_error(masks, flows, device0, multithread=multithread, logger=logger)
     badi = 1 + (merrors > threshold).nonzero()[0]
     masks[np.isin(masks, badi)] = 0
 
@@ -805,7 +807,6 @@ def get_masks(p, iscell=None, rpad=20, logger=None):
         dt = t2 - t1
         if logger is not None: logger.info(f'get_masks: maximum_filter1d : {timedelta(seconds=dt)}')
 
-    if logger is not None: logger.info(f'get_masks: big loop: pix: {len(pix)}')
     if logger is not None: logger.info(f'get_masks: big loop')
     t1 = time.monotonic()
     seeds = find_seeds(h, hmax)
@@ -934,12 +935,12 @@ def compute_masks(dP, cellprob, p=None, niter=200, cellprob_threshold=0.0,
                     if logger is not None: logger.info("Attempting remove_bad_flow_masks with default device.")
                     # print("Attempting remove_bad_flow_masks with default device.")
                     mask = remove_bad_flow_masks(mask, dP, threshold=flow_threshold,
-                                                device=device, logger=logger)
+                                                device=device, multithread=True, logger=logger)
                 except:
-                    if logger is not None: logger.info("Resorting to CPU for remove_bad_flow_masks.")
+                    if logger is not None: logger.info("Resorting to single CPU for remove_bad_flow_masks.")
                     # print("Resorting to CPU for remove_bad_flow_masks.")
                     mask = remove_bad_flow_masks(mask, dP, threshold=flow_threshold,
-                                                device= None, logger=logger)
+                                                device=None, multithread=False, logger=logger)
         if mask.max() > 2**16 - 1:
             recast = True
             mask = mask.astype(np.float32)

--- a/cellpose/dynamics.py
+++ b/cellpose/dynamics.py
@@ -15,6 +15,8 @@ import fastremap
 import logging
 from datetime import timedelta
 
+from .dynamics_parallelized import masks_to_flows_cpu_parallel
+
 dynamics_logger = logging.getLogger(__name__)
 
 from . import utils, metrics, transforms
@@ -337,9 +339,9 @@ def masks_to_flows(masks, device=None, niter=None):
         if device.type == "cuda" or device.type == "mps":
             masks_to_flows_device = masks_to_flows_gpu
         else:
-            masks_to_flows_device = masks_to_flows_cpu
+            masks_to_flows_device = masks_to_flows_cpu_parallel
     else:
-        masks_to_flows_device = masks_to_flows_cpu
+        masks_to_flows_device = masks_to_flows_cpu_parallel
 
     if masks.ndim == 3:
         Lz, Ly, Lx = masks.shape

--- a/cellpose/dynamics_parallelized.py
+++ b/cellpose/dynamics_parallelized.py
@@ -1,0 +1,310 @@
+import numpy as np
+from scipy.ndimage import find_objects
+
+import numba
+from numba import njit, prange
+
+
+@njit("(float64[:], int32[:], int32[:], int32, int32, int32, int32)", nogil=True)
+def _extend_centers(T, y, x, ymed, xmed, Lx, niter):
+    """Run diffusion from the center of the mask on the mask pixels.
+
+    Args:
+        T (numpy.ndarray): Array of shape (Ly * Lx) where diffusion is run.
+        y (numpy.ndarray): Array of y-coordinates of pixels inside the mask.
+        x (numpy.ndarray): Array of x-coordinates of pixels inside the mask.
+        ymed (int): Center of the mask in the y-coordinate.
+        xmed (int): Center of the mask in the x-coordinate.
+        Lx (int): Size of the x-dimension of the masks.
+        niter (int): Number of iterations to run diffusion.
+
+    Returns:
+        numpy.ndarray: Array of shape (Ly * Lx) representing the amount of diffused particles at each pixel.
+    """
+    for t in range(niter):
+        T[ymed * Lx + xmed] += 1
+        T[y * Lx +
+          x] = 1 / 9. * (T[y * Lx + x] + T[(y - 1) * Lx + x] + T[(y + 1) * Lx + x] +
+                         T[y * Lx + x - 1] + T[y * Lx + x + 1] +
+                         T[(y - 1) * Lx + x - 1] + T[(y - 1) * Lx + x + 1] +
+                         T[(y + 1) * Lx + x - 1] + T[(y + 1) * Lx + x + 1])
+    return T
+
+
+def _slices_to_ndarrays(slices: list[(slice, slice)]) -> (np.ndarray, np.ndarray):
+    """
+    Takes a list of (slice, slice) objects representing bounding boxes
+    on a 2D grid. Parses the start/end coordinates into int32 numpy arrays
+    for compatibility with downstream numba functions.
+
+    Objects are also validated here, with those with null extents being omitted.
+
+    Arguments:
+    - slices (tuple(slice, slice)): row and column slices passed from find_objects
+
+    Returns:
+    - labels (int32[:]): unique integer label for each valid object
+    - bounds (int32[:, 4]): array of each valid object's bounding box, ordered as (row_start, row_end, col_start, col_end)
+    """
+    labels = []
+    row_starts = []
+    row_ends = []
+    col_starts = []
+    col_ends = []
+    for i, si in enumerate(slices):
+        if si is None:
+            continue
+        labels.append(i)
+        rs, re = si[0].start, si[0].stop
+        cs, ce = si[1].start, si[1].stop
+        row_starts.append(rs)
+        row_ends.append(re)
+        col_starts.append(cs)
+        col_ends.append(ce)
+    labels = np.array(labels, dtype=np.int32)
+
+    row_starts = np.array(row_starts, dtype=np.int32)
+    row_ends = np.array(row_ends, dtype=np.int32)
+    col_starts = np.array(col_starts, dtype=np.int32)
+    col_ends = np.array(col_ends, dtype=np.int32)
+    bounds = np.stack([row_starts, row_ends, col_starts, col_ends], axis=1)
+    return labels, bounds
+
+
+@njit(inline='always')
+def _calculate_object_centroid(masks, label, row_start, row_end, col_start, col_end):
+    """
+    Calculates the centroid pixel of an object defined as where `masks == label`, and
+    bounded by (row_start, row_end, col_start, col_end).
+
+    Arguments:
+    - masks (uint32[:, :]): big array of unique object labels for each pixel
+    - label (int32): label of the object being processed
+    - row_start, row_end, col_start, col_end (int32): bounding box for the object on masks
+
+    Returns:
+    - (int32, int32) coordinates of the object centroid in its cropped coordinate frame
+    """
+
+    # Mean coordinate within the object
+    count = 0
+    sum_y = 0.0
+    sum_x = 0.0
+    for r in range(row_start, row_end):
+        for c in range(col_start, col_end):
+            if masks[r, c] == label + 1:
+                sum_y += (r - row_start + 1)
+                sum_x += (c - col_start + 1)
+                count += 1
+    if count == 0:  # should be unreachable as long as the objects are pre-validated
+        return -1, -1
+    mean_y = sum_y / count
+    mean_x = sum_x / count
+
+    # Argmin squared distance from the mean coordinate
+    min_dist = count
+    min_y = 0
+    min_x = 0
+    for r in range(row_start, row_end):
+        for c in range(col_start, col_end):
+            if masks[r, c] == label + 1:
+                obj_y = r - row_start + 1
+                obj_x = c - col_start + 1
+                dy = obj_y - mean_y
+                dx = obj_x - mean_x
+                dist = dy * dy + dx * dx
+                if dist < min_dist:
+                    min_dist = dist
+                    min_y = obj_y
+                    min_x = obj_x
+
+    return min_y - 1, min_x - 1
+
+
+@njit(parallel=True)
+def _calculate_all_centroids(masks, labels, bounds):
+    """
+    Parallel calculation of the centroids of all objects in masks.
+
+    Arguments:
+    - masks (uint32[:, :]): big array of unique object labels for each pixel
+    - labels (int32[:]): labels of all valid objects
+    - bounds (int32[:, 4]): bounding boxes for each object on masks
+
+    Returns:
+    - int32[:, 2] coordinates of each object's centroid in its cropped coordinate frame
+    """
+    n = labels.shape[0]
+    centroids = np.zeros((n, 2), dtype=np.int32)
+    for i in prange(n):
+        cy, cx = _calculate_object_centroid(masks,
+                                            label=labels[i],
+                                            row_start=bounds[i, 0],
+                                            row_end=bounds[i, 1],
+                                            col_start=bounds[i, 2],
+                                            col_end=bounds[i, 3]
+                                            )
+        centroids[i, 0] = cy
+        centroids[i, 1] = cx
+    return centroids
+
+
+@njit(inline='always')
+def _get_object_coordinates(masks, label, row_start, row_end, col_start, col_end):
+    """
+    Finds all coordinates within a bounding box where `masks == label+1`
+    and returns them as 1D arrays. Coordinates are defined relative to the full
+    masks frame.
+
+    Arguments:
+    - masks (uint32[:, :]): big array of unique object labels for each pixel
+    - label (int32): label of the object being processed
+    - row_start, row_end, col_start, col_end (int32): bounding box for the object on masks
+
+    Returns:
+    - (int32[:], int32[:]) flattened lists of the object's coordinates on masks
+    """
+    row_list = []
+    col_list = []
+    for i in range(row_start, row_end):
+        for j in range(col_start, col_end):
+            if masks[i, j] == label + 1:
+                row_list.append(i)
+                col_list.append(j)
+    row_list = np.array(row_list, dtype=np.int32)
+    col_list = np.array(col_list, dtype=np.int32)
+    return row_list, col_list
+
+
+@njit(inline='always')
+def _compute_flow(T, row_list_rel, col_list_rel, num_cols):
+    """
+    Given the flattened, diffused array T, calculate the gradients (dy, dx)
+    at the given mask coordinates. All coordinates are defined relative to
+    the object's cropped bounding box.
+
+    Arguments:
+    - T (float64[:]): flattened diffused field, from _extend_centers()
+    - row_list_rel (int32[:]): array of y-coordinates for the object under consideration
+    - col_list_rel (int32[:]): array of x-coordinates for the object under consideration
+    - num_cols (int32): width of the diffused field, for indexing into the flattened field
+
+    Returns:
+    - (float64[:], float64[:]) gradients
+    """
+    n = row_list_rel.shape[0]
+    dy = np.empty(n, dtype=T.dtype)
+    dx = np.empty(n, dtype=T.dtype)
+    for i in range(n):
+        r = row_list_rel[i]
+        c = col_list_rel[i]
+        dy[i] = T[(r + 1) * num_cols + c] - T[(r - 1) * num_cols + c]
+        dx[i] = T[r * num_cols + (c + 1)] - T[r * num_cols + (c - 1)]
+    return dy, dx
+
+
+@njit
+def _update_gradient_field(mu, row_list, col_list, dy, dx):
+    """
+    Updates `mu` in-place, writing (dy, dx) to the coordinates
+    specified by row_list and col_list.
+
+    Arguments:
+    - mu (float64[2, :, :]): gradient field to be modified
+    - row_list (int32[:]): array of y-coordinates for the object under consideration
+    - col_list (int32[:]): array of x-coordinates for the object under consideration
+    - dx, dy (float64[:]): flattened gradient values at the object's coordinates
+    """
+    n = dy.shape[0]
+    for i in range(n):
+        r = row_list[i]
+        c = col_list[i]
+        mu[0, r, c] = dy[i]
+        mu[1, r, c] = dx[i]
+
+
+@njit(parallel=True)
+def _get_all_gradients(masks, centroids, labels, bounds, niter):
+    """
+    Given a set of objects on masks, diffuse on each object in parallel
+    to calculate the corresponding gradient field.
+
+    Arguments:
+    - masks (uint32[:, :]): big array of unique object labels for each pixel
+    - centroids: int32[:, 2] coordinates of each object's centroid in its cropped coordinate frame
+    - labels (int32[:]): labels of all valid objects
+    - bounds (int32[:, 4]): bounding boxes for each object on masks
+    - niter (int32): number of iterations to expand (if None, calculated based on object size)
+
+    Returns:
+    - mu (float64[2, :, :]): gradient field for all objects
+    """
+
+    Ly, Lx = masks.shape
+    mu = np.zeros((2, Ly, Lx), np.float64)
+
+    n_objects = labels.shape[0]
+    for i in prange(n_objects):
+
+        if centroids[i][0] < 0 or centroids[i][1] < 0:
+            # _calculate_object_centroid returned (-1, -1) due to the object having a null span
+            continue
+
+        row_list, col_list = _get_object_coordinates(masks,
+                                                     label=labels[i],
+                                                     row_start=bounds[i, 0],
+                                                     row_end=bounds[i, 1],
+                                                     col_start=bounds[i, 2],
+                                                     col_end=bounds[i, 3])
+
+        row_list_rel = row_list - bounds[i, 0] + np.int32(1)
+        col_list_rel = col_list - bounds[i, 2] + np.int32(1)
+
+        ly = (bounds[i, 1] - bounds[i, 0]) + np.int32(2)
+        lx = (bounds[i, 3] - bounds[i, 2]) + np.int32(2)
+
+        n_iter = 2 * np.int32(ly + lx) if niter is None else niter
+        T = np.zeros(ly * lx, dtype=np.float64)
+        T = _extend_centers(T, row_list_rel, col_list_rel, centroids[i][0], centroids[i][1], lx, n_iter)
+        dy, dx = _compute_flow(T, row_list_rel, col_list_rel, lx)
+        _update_gradient_field(mu, row_list, col_list, dy, dx)
+
+    return mu
+
+
+def _normalize_gradient_field(mu):
+    """
+    Normalizes the gradient field in-place.
+
+    Arguments:
+    - mu (float64[2, :, :]
+    """
+    epsilon = 1e-60
+    mu /= (epsilon + (mu ** 2).sum(axis=0) ** 0.5)
+
+
+def masks_to_flows_cpu_parallel(masks, device=None, niter=None):
+    """
+    Same as dynamics.masks_to_flows_cpu(), but using numba to parallelize across objects.
+
+    Convert masks to flows using diffusion from center pixel.
+
+    Center of masks where diffusion starts is defined to be the closest pixel to the mean of all pixels that is inside the mask.
+    Result of diffusion is converted into flows by computing the gradients of the diffusion density map.
+
+    Args:
+        masks (int, 2D or 3D array): Labelled masks 0=NO masks; 1,2,...=mask labels
+        device: not used in this method
+
+    Returns:
+        tuple containing
+            - mu (float, 3D or 4D array): Flows in Y = mu[-2], flows in X = mu[-1].
+                If masks are 3D, flows in Z = mu[0].
+            - meds (float, 2D or 3D array): cell centers
+    """
+    slices = find_objects(masks)
+    labels, bounds = _slices_to_ndarrays(slices)
+    centroids = _calculate_all_centroids(masks, labels, bounds)
+    mu = _get_all_gradients(masks, centroids + 1, labels, bounds, niter)  # +1 to account for padding
+    _normalize_gradient_field(mu)
+    return mu, centroids

--- a/cellpose/metrics.py
+++ b/cellpose/metrics.py
@@ -232,7 +232,7 @@ def _true_positive(iou, th):
     return tp
 
 
-def flow_error(maski, dP_net, device=None, logger=None):
+def flow_error(maski, dP_net, device=None, multithread=True, logger=None):
     """Error in flows from predicted masks vs flows predicted by network run on image.
 
     This function serves to benchmark the quality of masks. It works as follows:
@@ -246,6 +246,8 @@ def flow_error(maski, dP_net, device=None, logger=None):
     Args:
         maski (np.ndarray, int): Masks produced from running dynamics on dP_net, where 0=NO masks; 1,2... are mask labels.
         dP_net (np.ndarray, float): ND flows where dP_net.shape[1:] = maski.shape.
+        device (torch.device, optional): Device to run masks_to_flows on. Defaults to None, for CPU.
+        multithread (bool, optional): Whether to run masks_to_flows using parallelized numba.
 
     Returns:
         flow_errors (np.ndarray, float): Mean squared error between predicted flows and flows from masks.
@@ -259,7 +261,7 @@ def flow_error(maski, dP_net, device=None, logger=None):
 
     if logger is not None: logger.info(f'flow_error: dynamics.masks_to_flows')
     t1 = time.monotonic()
-    dP_masks = dynamics.masks_to_flows(maski, device=device)
+    dP_masks = dynamics.masks_to_flows(maski, device=device, multithread=multithread)
     t2 = time.monotonic()
     dt = t2 - t1
     if logger is not None: logger.info(f'flow_error: dynamics.masks_to_flows: {timedelta(seconds=dt)}')

--- a/cellpose/models.py
+++ b/cellpose/models.py
@@ -305,6 +305,8 @@ class CellposeModel():
         if not self.gpu:
             self.mkldnn = check_mkl(True)
 
+        if isinstance(device_for_masks, str):
+            device_for_masks = torch.device(device_for_masks)
         self.device_for_masks = device_for_masks
 
         ### create neural network

--- a/cellpose/models.py
+++ b/cellpose/models.py
@@ -106,13 +106,14 @@ class Cellpose():
 
     """
 
-    def __init__(self, gpu=False, model_type="cyto3", nchan=2, device=None,
+    def __init__(self, gpu=False, model_type="cyto3", nchan=2, device=None, device_for_masks=torch.device("cpu"),
                  backbone="default"):
         super(Cellpose, self).__init__()
 
         # assign device (GPU or CPU)
         sdevice, gpu = assign_device(use_torch=True, gpu=gpu)
         self.device = device if device is not None else sdevice
+        self.device_for_masks = device_for_masks
         self.gpu = gpu
         self.backbone = backbone
 
@@ -129,8 +130,8 @@ class Cellpose():
                 f"cannot set nchan to other value for {model_type} model")
         self.nchan = nchan
 
-        self.cp = CellposeModel(device=self.device, gpu=self.gpu, model_type=model_type,
-                                diam_mean=self.diam_mean, nchan=self.nchan,
+        self.cp = CellposeModel(device=self.device, device_for_masks=device_for_masks, gpu=self.gpu,
+                                model_type=model_type, diam_mean=self.diam_mean, nchan=self.nchan,
                                 backbone=self.backbone)
         self.cp.model_type = model_type
 
@@ -237,7 +238,7 @@ class CellposeModel():
     """
 
     def __init__(self, gpu=False, pretrained_model=False, model_type=None,
-                 diam_mean=30., device=None, nchan=2, backbone="default"):
+                 diam_mean=30., device=None, device_for_masks=torch.device("cpu"), nchan=2, backbone="default"):
         """
         Initialize the CellposeModel.
 
@@ -247,6 +248,7 @@ class CellposeModel():
             model_type (str, optional): Any model that is available in the GUI, use name in GUI e.g. "livecell" (can be user-trained or model zoo).
             diam_mean (float, optional): Mean "diameter", 30. is built-in value for "cyto" model; 17. is built-in value for "nuclei" model; if saved in custom model file (cellpose>=2.0) then it will be loaded automatically and overwrite this value.
             device (torch device, optional): Device used for model running / training (torch.device("cuda") or torch.device("cpu")), overrides gpu input, recommended if you want to use a specific GPU (e.g. torch.device("cuda:1")).
+            device_for_masks (torch device, optional): Device used for compute_masks. Defaults to torch.device("cpu"), since the arrays are typically too big for a GPU.
             nchan (int, optional): Number of channels to use as input to network, default is 2 (cyto + nuclei) or (nuclei + zeros).
         """
         self.diam_mean = diam_mean
@@ -302,6 +304,8 @@ class CellposeModel():
         self.gpu = gpu if device is None else device_gpu
         if not self.gpu:
             self.mkldnn = check_mkl(True)
+
+        self.device_for_masks = device_for_masks
 
         ### create neural network
         self.nchan = nchan
@@ -585,7 +589,7 @@ class CellposeModel():
                     dP, cellprob, niter=niter, cellprob_threshold=cellprob_threshold,
                     flow_threshold=flow_threshold, interp=interp, do_3D=do_3D,
                     min_size=min_size, resize=None,
-                    device=self.device if self.gpu else None)
+                    device=self.device_for_masks)
             else:
                 masks, p = [], []
                 resize = [shape[1], shape[2]] if (not resample and
@@ -604,7 +608,7 @@ class CellposeModel():
                         resize=resize,
                         min_size=min_size if stitch_threshold == 0 or nimg == 1 else
                         -1,  # turn off for 3D stitching
-                        device=self.device if self.gpu else None,
+                        device=self.device_for_masks,
                         logger=logger)
                     masks.append(outputs[0])
                     p.append(outputs[1])


### PR DESCRIPTION
Optimizations for `follow_flows` and `get_masks`.  Meshgrid calculation is now more efficient, and the previously-designated 'big loop' has been vectorized and factored out into its own `iterative_expansion` method.

`get_masks` should be a couple minutes faster per sample, with several-fold lower peak memory usage; `follow_flows` runtime is largely unchanged (was already pretty quick), but memory usage has been brought down to ~half.

Confirmed that running `segmentation_well` on five samples from G51_067 produces numerically identical results in this branch vs. the parent.